### PR TITLE
When supplying path with no defaults: ERROR: facl[/opt/path/name.file] FrozenError

### DIFF
--- a/resources/facl.rb
+++ b/resources/facl.rb
@@ -53,8 +53,12 @@ action :set do
     default: new_resource.default,
   }
   # If there are no default acl entries for things, specify blank hashes so diff_facl works
-  [:user, :group, :other, :mask].each do |symbol|
-    new_resource.facl[:default][symbol] = {} unless new_resource.facl[:default].key?(symbol)
+  # If path is a file, then no defaults should be given, if defaults are given, even empty ones
+  #   then error will be thrown below
+  if ::File.directory?(new_resource.path)
+    [:user, :group, :other, :mask].each do |symbol|
+      new_resource.facl[:default][symbol] = {} unless new_resource.facl[:default].key?(symbol)
+    end
   end
 
   recurse = new_resource.recurse


### PR DESCRIPTION
ets_facl::default line 118) had an error: FrozenError: can't modify frozen Hash

I was getting this error with:
```
    System Info:
    ------------
    chef_version=15.14.0
    platform=oracle
    platform_version=7.8
    ruby=ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-linux]
    program_name=chef-client worker: ppid=44390;start=14:22:56;
    executable=/opt/chef/bin/chef-client
```

I also saw this in my kitchen testing with chef 14 defined.

This happened when I only supplied what I needed:

facl path do
  group :group_name => 'rX'
end

Signed-off-by: Kevin J. Smith <kevin.j.smith2@cerner.com>